### PR TITLE
[XLA] Explicitly instantiate Permute template func

### DIFF
--- a/tensorflow/compiler/xla/service/llvm_ir/ir_array.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/ir_array.cc
@@ -158,7 +158,7 @@ IrArray::Index IrArray::Index::SourceIndexOfTranspose(
     tensorflow::gtl::ArraySlice<int64> dimension_mapping,
     llvm::IRBuilder<>* builder) const {
   std::vector<llvm::Value*> operand_multidim_index =
-      Permute(dimension_mapping, multidim());
+      Permute<std::vector, llvm::Value*>(dimension_mapping, multidim());
   if (linear() != nullptr &&
       ShapeUtil::TransposeIsBitcast(operand_shape, shape, dimension_mapping)) {
     return Index(operand_multidim_index, linear(), operand_shape);


### PR DESCRIPTION
This is an attempted fix for older compilers that can't deduce the template args.